### PR TITLE
fix: move output settings to output subsection

### DIFF
--- a/book.toml
+++ b/book.toml
@@ -4,6 +4,8 @@ language = "en"
 multilingual = false
 src = "src"
 title = "Computer Touching at Reed: CSTAR's Guide"
+
+[output.html]
 git-repository-url = "https://github.com/Reed-CSTAR/guides"
 git-repository-icon = "fa-github"
 edit-url-template = "https://github.com/Reed-CSTAR/guides/edit/main/{path}"


### PR DESCRIPTION
fixes my [bad commit](https://github.com/Reed-CSTAR/guides/commit/d38e9f398e5b15b60d19e84381fa55c4d3ee0152) (this new change works locally)